### PR TITLE
fix incompatible versions in package.json

### DIFF
--- a/services/jobs/package.json
+++ b/services/jobs/package.json
@@ -18,7 +18,7 @@
     "typeorm": "typeorm-ts-node-commonjs"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/auto-instrumentations-node": "0.28.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.27.0",
     "@opentelemetry/instrumentation-dns": "^0.29.0",


### PR DESCRIPTION
Currently `npm install` fails with the following error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: jobs-service@0.0.0
npm ERR! Found: @opentelemetry/api@1.1.0
npm ERR! node_modules/@opentelemetry/api
npm ERR!   @opentelemetry/api@"^1.1.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @opentelemetry/api@">=1.0.0 <1.1.0" from @opentelemetry/sdk-node@0.27.0
npm ERR! node_modules/@opentelemetry/sdk-node
npm ERR!   @opentelemetry/sdk-node@"0.27.0" from the root project
```

It looks like `@opentelemetry/sdk-node@0.27.0` explicitly does not support `@opentelemetry/api@1.1.0`