### PR TITLE
Handle errors in JobController.ts save() and `cancel()`

### DIFF
--- a/services/jobs/src/controllers/JobController.ts
+++ b/services/jobs/src/controllers/JobController.ts
@@ -82,17 +82,22 @@ export class JobController {
       ))
     )
       return res.status(403).send("Forbidden");
-    let job = this.jobRepository().create({
-      ...body,
-      creatorId: user.username,
-      repoId: repo.id,
-    } as DeepPartial<Job>);
-    job = await this.jobRepository().save(job);
-    // await oso.bulkTell([
-    //   ["has_relation", { type: "User", id: user.username }, "creator", { type: "Job", id: job.id.toString() }],
-    //   ["has_relation", { type: "Job", id: job.id.toString() }, "repository", { type: "Repository", id: repo.id }],
-    // ]);
-    return res.status(201).json(job);
+
+    try {
+      let job = this.jobRepository().create({
+        ...body,
+        creatorId: user.username,
+        repoId: repo.id,
+      } as DeepPartial<Job>);
+      job = await this.jobRepository().save(job);
+      // await oso.bulkTell([
+      //   ["has_relation", { type: "User", id: user.username }, "creator", { type: "Job", id: job.id.toString() }],
+      //   ["has_relation", { type: "Job", id: job.id.toString() }, "repository", { type: "Repository", id: repo.id }],
+      // ]);
+      return res.status(201).json(job);
+    } catch (err) {
+      return res.status(500).json({ message: err.message });
+    }
   }
 
   async cancel({ oso, params, repo, user }: Request, res: Response) {
@@ -104,12 +109,17 @@ export class JobController {
       ))
     )
       return res.status(403).send("Forbidden");
-    const job = await this.jobRepository().findOneOrFail({
-      where: { id: parseInt(params.id) },
-    });
-    // if (!(await oso.authorize({ type: "User", id: user.username }, "cancel", { type: "Job", id: job.id.toString() })))
-    //   return res.status(403).send("Forbidden");
-    await this.jobRepository().update(job.id, { status: "canceled" });
-    return res.json(job);
+
+    try {
+      const job = await this.jobRepository().findOneOrFail({
+        where: { id: parseInt(params.id) },
+      });
+      // if (!(await oso.authorize({ type: "User", id: user.username }, "cancel", { type: "Job", id: job.id.toString() })))
+      //   return res.status(403).send("Forbidden");
+      await this.jobRepository().update(job.id, { status: "canceled" });
+      return res.json(job);
+    } catch (err) {
+      return res.status(500).json({ message: err.message });
+    }
   }
 }


### PR DESCRIPTION
Right now, not specifying `name` when calling `save()` makes server crash:

```
/Users/val/Workspace/meanIT/gitcloud/services/jobs/node_modules/typeorm/src/driver/sqlite/SqliteQueryRunner.ts:113
                    fail(new QueryFailedError(query, parameters, err))
                         ^
QueryFailedError: SQLITE_CONSTRAINT: NOT NULL constraint failed: job.name
    at Statement.handler (/gitcloud/services/jobs/node_modules/typeorm/src/driver/sqlite/SqliteQueryRunner.ts:113:26) {
  query: `INSERT INTO "job"("id", "name", "status", "repoId", "creatorId", "createdAt", "updatedAt") VALUES (NULL, NULL, 'scheduled', ?, ?, datetime('now'), datetime('now'))`,
  parameters: [ 'tps-reports', 'Bill' ],
  driverError: [Error: SQLITE_CONSTRAINT: NOT NULL constraint failed: job.name] {
    errno: 19,
    code: 'SQLITE_CONSTRAINT'
  },
  errno: 19,
  code: 'SQLITE_CONSTRAINT'
}
[nodemon] app crashed - waiting for file changes before starting...
[nodemon] restarting due to changes...
```

With this PR, you get an error message back in HTTP instead:

```
$ curl -X POST -d '{}' -H "Content-Type: application/json" -H "x-user-id: Bill" http://localhost:5001/orgs/acme/repos/tps-reports/jobs
{"message":"SQLITE_CONSTRAINT: NOT NULL constraint failed: job.name"}
```