### PR TITLE
add FAQ about Airplay and port 5000 on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,10 @@ curl -c gitclub.cookies -H "Content-Type: application/json" -X POST -d '{"userna
 ```bash
 curl -b gitclub.cookies localhost:5000/orgs/1
 ```
+
+## FAQ
+
+### I'm getting "Failed to fetch" CORS errors on Mac
+
+Try [disabling Airplay](https://developer.apple.com/forums/thread/693768), Airplay can intercept requests to `localhost:5000`.
+In the Chrome console, check the "server" response header on a failed request: if the "server" response header includes "Airplay", then Airplay is the culprit.


### PR DESCRIPTION
I kept running into CORS errors trying to run the frontend, and it turns out the issue was that Airplay was intercepting requests to localhost:5000 in my browser as described here: https://developer.apple.com/forums/thread/693768. I disabled Airplay and everything works great. I figured I'd leave a note in the README in case someone else runs into a similar issue trying to run this project.