### PR TITLE
ENG-376 docker compose setup for running GitCloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 venv/
 .vim/
 .envrc
+.DS_Store
+gitcloud-data/
 !.vscode/settings.json

--- a/Dockerfile.oso
+++ b/Dockerfile.oso
@@ -1,0 +1,23 @@
+# start with a minimal image
+FROM debian:bookworm-slim
+
+# get base dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -Ol https://oso-local-development-binary.s3.amazonaws.com/latest/oso-local-development-binary-linux-x86_64.tar.gz
+RUN tar -zxvf ./oso-local-development-binary-linux-x86_64.tar.gz
+RUN chmod +x ./standalone
+RUN echo "export PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc
+
+RUN mkdir -p /data
+
+ENV OSO_DIRECTORY=/data
+ENV OSO_PORT=8081
+ENV OSO_FEATURES="reconcile-facts-update"
+
+COPY ./policy/authorization.polar /authorization.polar
+
+CMD ["./standalone", "authorization.polar"]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ test-policy: require-OSO_AUTH
 update-policy: policy/authorization.polar
 	oso-cloud policy policy/authorization.polar
 
+seed:
+	curl -X POST http://localhost:5000/_seed
+
 require-%:
 	$(if ${${*}},,$(error You must pass the $* environment variable))
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ frontend-1  | ready - started server on 0.0.0.0:8000, url: http://localhost:8000
 
 If this is your first time running `docker-compose up`, you will also need to seed your local Postgres database by running `make seed`.
 
+#### Docker Troubleshooting
+
+If you run into the following error when running `docker-compose up`, run `ALTER TABLE users DROP CONSTRAINT IF EXISTS pg_type_typname_nsp_index;` to clean up the dangling unique constraint.
+
+```
+psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "pg_type_typname_nsp_index"
+```
+
+You can run this code from Python using the following:
+
+```python
+with engine.connect() as conn:
+    conn.execute('ALTER TABLE users DROP CONSTRAINT IF EXISTS pg_type_typname_nsp_index')
+```
+
 ## Frontend
 
 ### Running the frontend

--- a/README.md
+++ b/README.md
@@ -101,6 +101,32 @@ Run the Jobs Service in another terminal:
 make -C services/jobs
 ```
 
+### Running with Docker
+
+You can run all the services at once, along with a Oso Cloud local development binary and Postgres instance, using Docker Compose:
+
+```
+docker-compose up
+```
+
+This repo's `docker-compose.yml` file starts the following services:
+
+1. GitClub on port 5000
+2. Jobs Service on port 5001
+3. Oso Cloud local development binary on port 8081
+4. Postgres on port 5432
+5. Next.js frontend on port 8000
+
+If `docker-compose up` ran successfully, you should see the following output.
+
+```
+frontend-1  | yarn run v1.22.19
+frontend-1  | $ next start
+frontend-1  | ready - started server on 0.0.0.0:8000, url: http://localhost:8000
+```
+
+If this is your first time running `docker-compose up`, you will also need to seed your local Postgres database by running `make seed`.
+
 ## Frontend
 
 ### Running the frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  gitclub:
+    build:
+      context: services/gitclub
+      dockerfile: Dockerfile
+    depends_on:
+      - postgres
+      - oso
+    ports:
+      - "5000:5000"
+    environment:
+      - OSO_AUTH=e_0123456789_12345_osotesttoken01xiIn
+      - OSO_URL=http://oso:8081
+      - PRODUCTION_DB=1
+      - DATABASE_URL=postgresql://oso:password@postgres:5432/gitcloud
+
+  jobs:
+    build:
+      context: services/jobs
+      dockerfile: Dockerfile
+    ports:
+      - "5001:5001"
+    depends_on:
+      - oso
+    environment:
+      - OSO_AUTH=e_0123456789_12345_osotesttoken01xiIn
+      - OSO_URL=http://oso:8081
+
+  oso:
+    build:
+      dockerfile: Dockerfile.oso
+    ports:
+      - "8081:8081"
+    environment:
+      - OSO_AUTH=e_0123456789_12345_osotesttoken01xiIn
+      - OSO_URL=http://localhost:8081
+
+  postgres:
+    image: postgres:14-alpine
+    ports:
+      - 5433:5432
+    volumes:
+      - ./gitcloud-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_USER=oso
+      - POSTGRES_DB=gitcloud
+
+  frontend:
+    build:
+      context: frontend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    depends_on:
+      - gitclub
+      - jobs

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+# Use the official Node.js image as the base image
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --production
+COPY . .
+RUN yarn build
+
+# Expose the port Next.js will run on
+EXPOSE 8000
+ENV PORT 8000
+
+# Command to start the Next.js app
+CMD ["yarn", "start"]

--- a/services/gitclub/Dockerfile
+++ b/services/gitclub/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.12.7-alpine
 
 COPY requirements.txt /app/requirements.txt
 RUN \

--- a/services/gitclub/app/__init__.py
+++ b/services/gitclub/app/__init__.py
@@ -26,7 +26,6 @@ WEB_URL = (
     else os.environ.get("WEB_URL", "http://localhost:8000")
 )
 
-
 def create_app(db_path="sqlite:///roles.db", load_fixtures=False):
     from . import routes
 
@@ -89,6 +88,12 @@ def create_app(db_path="sqlite:///roles.db", load_fixtures=False):
         with open("../../policy/authorization.polar") as f:
             policy = f.read()
             oso.policy(policy)
+        load_fixture_data(Session())
+        return {}
+    
+    @app.route("/_seed", methods=["POST"])
+    def seed():
+        Base.metadata.create_all(bind=engine)
         load_fixture_data(Session())
         return {}
 

--- a/services/jobs/Dockerfile
+++ b/services/jobs/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18
+
+RUN apt-get update && apt-get install -y \
+    sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+WORKDIR /home/node/app
+COPY package*.json ./
+
+USER node
+RUN yarn install
+COPY --chown=node:node . .
+EXPOSE 5001
+CMD [ "yarn", "start" ]

--- a/services/jobs/Dockerfile
+++ b/services/jobs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 RUN apt-get update && apt-get install -y \
     sqlite3 \


### PR DESCRIPTION
Added Dockerfiles for `services/jobs`, `frontend`, and Oso local binary. And added a docker-compose that can run gitcloud, jobs, frontend, Oso local binary, and postgres. I wasn't able to figure out how to reliably seed the db without making some substantial changes, so I just added a separate seed script to the `services/gitclub` Makefile with instructions to only run that seed script once.